### PR TITLE
Updated Dockerfile to use distroless for final image; shrinks runtime image from 124MB to 74MB!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM python:3.8.2-alpine3.11
+# Whole cloth lifted from https://github.com/GoogleContainerTools/distroless/blob/a7156f6ff9d15892e726dd2368cb2383d40f9d04/examples/python3-requirements/Dockerfile
+FROM debian:buster-slim AS build
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip
+
+FROM build AS build-venv
+COPY requirements.txt /requirements.txt
+RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
+
+FROM gcr.io/distroless/python3-debian10
 LABEL MAINTAINER="jskii <blackdanieljames@gmail.com>"
-
-ENV CONTAINERIZED=True
-ADD requirements.txt /requirements.txt
-RUN pip install -r requirements.txt
+COPY --from=build-venv /venv /venv
+COPY download-otf-videos.py /app/download-otf-videos.py
 WORKDIR /app
-ADD download-otf-videos.py /app/download-otf-videos.py
-
-ENTRYPOINT ["python3", "download-otf-videos.py"]
+ENTRYPOINT ["/venv/bin/python3", "download-otf-videos.py"]


### PR DESCRIPTION
```
jski/otf-youtube-workout-downloader          latest              0dc2e40884e5        13 seconds ago      73.9MB
jski/otf-youtube-workout-downloader          alpine              3826f7d65768        4 days ago          124MB
```